### PR TITLE
renaming inputs to data_n

### DIFF
--- a/code/shiny_cards.R
+++ b/code/shiny_cards.R
@@ -105,7 +105,7 @@ ideogramPlotDashServer <- function (id, data) {
                  height = card_contents_height)
       })
       output$ideogram_card_render <- renderPlot({
-        make_ideogram(location_data = gene_location, chromosome_data = chromosome, input = data(), card = TRUE)
+        make_ideogram(input = data(), card = TRUE)
       })
     })
 }
@@ -152,7 +152,7 @@ pubmedPlotDashServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% pubmed$name, "No literature found"))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_pubmed", card = TRUE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_pubmed", card = TRUE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("pubmed_gene_card_image"))
         } else {
@@ -206,7 +206,7 @@ cellExpressionPlotDashServer <- function (id, data) {
           )
         }
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_cellexpression", card = TRUE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_cellexpression", card = TRUE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("expression_gene_card_image"))
         } else {
@@ -248,7 +248,7 @@ cellAnatogramPlotDashServer <- function (id, data) {
           need(data()$content %in% subcell$gene_name, "No subcellular location data for this gene.")
         )
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_cellanatogram", card = TRUE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_cellanatogram", card = TRUE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("cell_anatogram_gene_card_image"))
         } else {
@@ -290,7 +290,7 @@ tissueAnatogramPlotDashServer <- function (id, data) {
           need(data()$content %in% tissue$gene_name, "No data found for this gene.")
         )
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_female_anatogram", card = TRUE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_female_anatogram", card = TRUE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("tissue_anatogram_gene_card_image"))
         } else {
@@ -748,7 +748,7 @@ pubmedCompoundPlotDashServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% pubmed$name, "No literature found"))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_pubmed", card = TRUE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_pubmed", card = TRUE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("pubmed_compound_card_image"))
         } else {
@@ -782,7 +782,7 @@ drugGenesCorTableDashServer <- function (id, data) {
       output$druggenescortabledash <- render_gt({
         shiny::validate(
           need(data()$content %in% drug_genes_cor_table$fav_drug, "No gene data found for this compound."))
-        gt::gt(make_drug_genes_cor_table(drug = data()$content) %>% 
+        gt::gt(make_drug_genes_cor_table(data()$content) %>% 
                  dplyr::mutate("Rank" = row_number()) %>% 
                  dplyr::select(Rank, Gene = gene, 'R^2'=r2) %>% 
                  dplyr::slice(1:5))
@@ -812,7 +812,7 @@ geneGoTableTabServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% unique(unlist(pathways$data, use.names = FALSE)), "GO Term pathways")
         )
-        gt::gt(make_pathway_list(table_name = pathways, input = data()) %>% 
+        gt::gt(make_pathway_list(input = data()) %>% 
                  #dplyr::mutate(go = map_chr(go, internal_link))  %>% #from fun_helper.R
                  dplyr::select(Pathway = pathway, GO = go) %>%
                  dplyr::slice(1))
@@ -1339,8 +1339,8 @@ cellDependenciesDensityPlotTabServer <- function (id, data) {
         #check to see if data are there
         shiny::validate(
           need(data()$content %in% achilles_long$gene |
-                               data()$content %in% expression_meta$cell_line, 
-                             "No data found for this query."))
+                 data()$content %in% expression_meta$cell_line, 
+               "No data found for this query."))
         #check to see if image exists
         img_path <- ddh::load_image(input = data(), fun_name = "make_cellbins", card = TRUE)
         if(!is.null(img_path)) {
@@ -1441,7 +1441,7 @@ cellDepsSubLinPlotTabServer <- function (id, data) {
       })
       output$cell_dependencies_sublineageplot_tab_render <- renderPlot({
         make_sublineage(input = data(),
-                     card = TRUE)
+                        card = TRUE)
       })
     }
   )
@@ -1463,8 +1463,8 @@ expdepPlotTabServer <- function (id, data) {
         #check to see if data are there
         shiny::validate(
           need(data()$content %in% achilles_long$gene |
-                               data()$content %in% expression_meta$cell_line, 
-                             "No data found for this query."))
+                 data()$content %in% expression_meta$cell_line, 
+               "No data found for this query."))
         #check to see if image exists
         img_path <- ddh::load_image(input = data(), fun_name = "make_expdep", card = TRUE)
         if(!is.null(img_path)) {

--- a/code/shiny_helper.R
+++ b/code/shiny_helper.R
@@ -5,11 +5,6 @@ notZeroConditionalPanel <- function(fieldname, ...) {
   conditionalPanel(condition = condition_str, ...)  
 }
 
-# toggleConditionPanel <- function(fieldname, ...) {
-#   condition_str <- paste0("input['", fieldname, "'] %% 2 != 0")
-#   conditionalPanel(condition = condition_str, ...)
-# }
-
 # dynamicSwitch <- function(fieldname, ...) {
 #   prettySwitch(
 #     inputId = fieldname,

--- a/code/shiny_plots.R
+++ b/code/shiny_plots.R
@@ -24,7 +24,7 @@ ideogramPlotServer <- function (id, data) {
           need(data()$content %in% gene_location$approved_symbol, 
                "No data found for this gene."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_ideogram", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_ideogram", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("ideogram_plot_image"), width = "100%")
         } else {
@@ -38,7 +38,7 @@ ideogramPlotServer <- function (id, data) {
                      width = "100%"))
       })
       output$ideogram_plot_render <- renderPlot({
-        make_ideogram(location_data = gene_location, chromosome_data = chromosome, input = data())
+        make_ideogram(input = data())
       })
     }
   )
@@ -66,7 +66,7 @@ proteinSizePlotServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% proteins$gene_name, "No protein mass found"))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_proteinsize", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_proteinsize", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("protein_size_plot_image"), width = "100%")
         } else {
@@ -669,7 +669,7 @@ pubmedPlotServer <- function (id, data, session) {
         shiny::validate(
           need(data()$content %in% pubmed$name, "No literature found"))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_pubmed", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_pubmed", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("pubmed_plot_image"), width = "100%")
         } else {
@@ -713,7 +713,7 @@ pubmedCompoundPlotServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% pubmed$name, "No literature found"))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_pubmed", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_pubmed", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("pubmed_compound_plot_image"), width = "100%")
         } else {
@@ -757,7 +757,7 @@ pubmedCellLinePlotServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% pubmed$name, "No literature found"))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_pubmed", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_pubmed", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("pubmed_cell_plot_image"), width = "100%")
         } else {
@@ -800,7 +800,7 @@ cellAnatogramPlotServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% subcell$gene_name, "No subcellular location data for this gene."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_cellanatogram", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_cellanatogram", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("cell_anatogram_gene_plot_image"), width = "100%")
         } else {
@@ -860,7 +860,7 @@ maleAnatogramPlotServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% tissue$gene_name, "No Tissue-specific expression data for this gene."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_male_anatogram", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_male_anatogram", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("male_anatogram_gene_plot_image"), width = "100%")
         } else {
@@ -894,7 +894,7 @@ femaleAnatogramPlotServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% tissue$gene_name, "No Tissue-specific expression data for this gene."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_female_anatogram", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_female_anatogram", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("female_anatogram_gene_plot_image"), width = "100%")
         } else {
@@ -932,7 +932,7 @@ tissuePlotServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% tissue$gene_name, "No Tissue-specific expression data for this gene."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_tissue", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_tissue", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("tissue_gene_plot_image"), width = "100%")
         } else {
@@ -946,7 +946,7 @@ tissuePlotServer <- function(id, data) {
                      width = "100%"))
       })
       output$tissue_gene_plot_render <- renderPlot({
-        make_tissue(tissue, input = data())
+        make_tissue(input = data())
       }, height = 1000)
     }
   )
@@ -987,7 +987,7 @@ cellGeneExpressionPlotServer <- function(id, data) {
           )
         }
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_cellexpression", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_cellexpression", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("expression_gene_plot_image"), width = "100%")
         } else {
@@ -1154,7 +1154,7 @@ cellDependenciesPlotServer <- function (id, data) {
                  data()$content %in% expression_meta$cell_line, 
                "No data found for this query."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_celldeps", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_celldeps", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("cell_deps_plot_image"), width = "100%")
         } else {
@@ -1331,7 +1331,7 @@ cellDependenciesCorrPlotServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% achilles_cor_nest$fav_gene, "No data found for this gene."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_correlation", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_correlation", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("gene_correlation_plot_image"), width = "100%")
         } else {
@@ -1614,7 +1614,7 @@ compoundStructureServer <- function (id, data) {
         shiny::validate(
           need(is.array(make_molecule_structure(input = data())), "No structure found for this compound."))
         #check to see if image exists
-        img_path <- ddh::load_image(input = data(), fun_name =  "make_molecule_structure", card = FALSE)
+        img_path <- ddh::load_image(input = data(), fun_name = "make_molecule_structure", card = FALSE)
         if(!is.null(img_path)) {
           uiOutput(outputId = session$ns("compound_structure_image"), width = "100%")
         } else {

--- a/code/shiny_tables.R
+++ b/code/shiny_tables.R
@@ -58,7 +58,7 @@ pathwayListServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% unique(unlist(pathways$data, use.names = FALSE)), "Not found in any pathways")
         )
-        DT::datatable(make_pathway_list(table_name = pathways, input = data()) %>% 
+        DT::datatable(make_pathway_list(input = data()) %>% 
                         dplyr::mutate(go = map_chr(go, internal_link))  %>% #from fun_helper.R
                         dplyr::select(Pathway = pathway, GO = go),
                       escape = FALSE,
@@ -85,7 +85,7 @@ pathwayGeneListServer <- function(id, data) {
       output$pathway_gene_list <- DT::renderDataTable({
         shiny::validate(
           need(data()$query %in% pathways$go, "Not found in any pathways"))
-        DT::datatable(make_pathway_genes(table_name = pathways, table_join = gene_summary, go_id = data()$query) %>% 
+        DT::datatable(make_pathway_genes(go_id = data()$query) %>% 
                         dplyr::mutate(gene = map_chr(gene, internal_link))  %>% #from fun_helper.R
                         dplyr::select(Gene = gene, Name = approved_name, AKA = aka),
                       escape = FALSE,
@@ -257,7 +257,7 @@ pubmedTableServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% pubmed$name, "No data found for this query"))
         withProgress(message = 'Building a smart table...', {
-          DT::datatable(make_pubmed_table(pubmed, input = data()) %>% 
+          DT::datatable(make_pubmed_table(input = data()) %>% 
                           dplyr::mutate(pmid = map_chr(pmid, pubmed_linkr, number_only = TRUE) #from fun_helper.R
                           ) %>% 
                           dplyr::mutate(pmcid = map_chr(pmcid, pmc_linkr) #from fun_helper.R
@@ -287,7 +287,7 @@ cellAnatogramTableServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% subcell$gene_name, 
                "No data for this gene"))
-        DT::datatable(make_cellanatogram_table(subcell, input = data()) %>% 
+        DT::datatable(make_cellanatogram_table(input = data()) %>% 
                         dplyr::select(Gene, gene, Reliability, Location) %>% 
                         dplyr::rename(`ENSEMBL ID` = gene),
                       options = list(pageLength = 10))
@@ -311,7 +311,7 @@ tissueTableServer <- function(id, data) {
       output$tissueanatogram_table <- DT::renderDataTable({
         shiny::validate(
           need(data()$content %in% tissue$gene_name, "No Tissue Expression Data Found"))
-        DT::datatable(make_humananatogram_table(tissue, input = data()),
+        DT::datatable(make_humananatogram_table(input = data()),
                       filter = if(input$tissue_filter_click == FALSE) {'none'} else {'top'},
                       options = list(pageLength = 10))
       })
@@ -622,7 +622,7 @@ similarPathwaysTableServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% master_positive$fav_gene, "No data found for this gene."))
         DT::datatable(
-          make_enrichment_top(master_positive, input = data()) %>% 
+          make_enrichment_top(input = data()) %>% 
             dplyr::mutate_if(is.numeric, ~ signif(., digits = 3)),
           options = list(pageLength = 25))
       })  
@@ -914,7 +914,7 @@ dissimilarPathwaysTableServer <- function (id, data) {
         shiny::validate(
           need(data()$content %in% master_negative$fav_gene, "No data found for this gene."))
         DT::datatable(
-          make_enrichment_bottom(master_negative, input = data()) %>% 
+          make_enrichment_bottom(input = data()) %>% 
             dplyr::mutate_if(is.numeric, ~ signif(., digits = 3)),
           options = list(pageLength = 25))
       })      
@@ -1163,7 +1163,7 @@ pubmedCompoundTableServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% pubmed$name, ""))
         withProgress(message = 'Building a smart table...', {
-          DT::datatable(make_pubmed_table(pubmed, input = data()) %>% 
+          DT::datatable(make_pubmed_table(input = data()) %>% 
                           dplyr::mutate(pmid = map_chr(pmid, pubmed_linkr, number_only = TRUE) #from fun_helper.R
                           ) %>% 
                           dplyr::mutate(pmcid = map_chr(pmcid, pmc_linkr) #from fun_helper.R
@@ -1190,7 +1190,7 @@ pubmedCellLineTableServer <- function(id, data) {
         shiny::validate(
           need(data()$content %in% pubmed$name, ""))
         withProgress(message = 'Building a smart table...', {
-          DT::datatable(make_pubmed_table(pubmed, input = data()) %>% 
+          DT::datatable(make_pubmed_table(input = data()) %>% 
                           dplyr::mutate(pmid = map_chr(pmid, pubmed_linkr, number_only = TRUE) #from fun_helper.R
                           ) %>% 
                           dplyr::mutate(pmcid = map_chr(pmcid, pmc_linkr) #from fun_helper.R
@@ -1225,7 +1225,7 @@ drugGenesTableServer <- function (id, data) {
       output$drug_genes_table <- DT::renderDataTable({
         shiny::validate(
           need(data()$content %in% drug_genes_table$fav_drug, "No gene data found for this compound."))
-        DT::datatable(make_drug_genes_table(drug = data()$content) %>% 
+        DT::datatable(make_drug_genes_table(data()$content) %>% 
                         dplyr::mutate(fav_gene = map_chr(fav_gene, internal_link)) %>% #from fun_helper.R
                         dplyr::rename(Drug = fav_drug, Gene = fav_gene, Name = approved_name), 
                       escape = FALSE)
@@ -1261,7 +1261,7 @@ drugGenesCorTableServer <- function (id, data) {
         #drug_gene_list will grab a char vec of genes known to be targeted compound, so we can check if corr's are known; added ifelse logic so index grab doesn't break
         drug_gene_tibble <- drug_genes_table %>% filter(fav_drug %in% data()$content)
         drug_gene_list <- ifelse(nrow(drug_gene_tibble) != 0, drug_gene_tibble %>% unnest(data) %>% pull(fav_gene), "")
-        DT::datatable(make_drug_genes_cor_table(drug = data()$content) %>% 
+        DT::datatable(make_drug_genes_cor_table(data()$content) %>% 
                         dplyr::mutate(
                           known = case_when(
                             gene %in% drug_gene_list ~ "TRUE", 

--- a/code/shiny_text.R
+++ b/code/shiny_text.R
@@ -75,7 +75,7 @@ summaryListTextServer <- function(id, data) {
     id,
     function(input, output, session) {
       output$query_list_summary <- renderText({
-        summary_list(input = data()) %>% 
+        make_summary_list(input = data()) %>% 
           lit_linkr(summary_table = gene_summary) # see fun_helper.R
       })
     }
@@ -95,7 +95,7 @@ geneTitleServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$gene_summary_title <- renderText({paste0(summary_gene(summary_table = gene_summary, input = data(), var = "approved_symbol"), ": ", summary_gene(summary_table = gene_summary, input = data(), var = "approved_name"))})
+      output$gene_summary_title <- renderText({paste0(make_summary_gene(input = data(), var = "approved_symbol"), ": ", make_summary_gene(input = data(), var = "approved_name"))})
     }
   )
 }
@@ -110,7 +110,7 @@ pathwayTitleServer <- function(id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$pathway_title <- renderText({paste0("Pathway: ", summary_pathway(summary_table = pathways, input = data(), var = "pathway"), " (GO:", summary_pathway(summary_table = pathways, input = data(), var = "go"), ")")})
+      output$pathway_title <- renderText({paste0("Pathway: ", make_summary_pathway(input = data(), var = "pathway"), " (GO:", make_summary_pathway(input = data(), var = "go"), ")")})
     }
   )
 }
@@ -133,20 +133,20 @@ geneTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$gene_summary_title <- renderText({paste0(summary_gene(summary_table = gene_summary, input = data(), var = "approved_symbol"), ": ", summary_gene(summary_table = gene_summary, input = data(), var = "approved_name"))})
-      output$gene_summary_approved_symbol <- renderText(summary_gene(summary_table = gene_summary, input = data(), var = "approved_symbol"))
-      output$gene_summary_approved_name <- renderText(summary_gene(summary_table = gene_summary, input = data(), var = "approved_name"))
-      output$gene_summary_aka <- renderText(summary_gene(summary_table = gene_summary, input = data(), var = "aka"))
-      output$gene_length <- renderText(paste0(summary_gene(summary_table = gene_location, input = data(), var = "cds_length"), " bp"))
+      output$gene_summary_title <- renderText({paste0(make_summary_gene(input = data(), var = "approved_symbol"), ": ", make_summary_gene(input = data(), var = "approved_name"))})
+      output$gene_summary_approved_symbol <- renderText(make_summary_gene(input = data(), var = "approved_symbol"))
+      output$gene_summary_approved_name <- renderText(make_summary_gene(input = data(), var = "approved_name"))
+      output$gene_summary_aka <- renderText(make_summary_gene(input = data(), var = "aka"))
+      output$gene_length <- renderText(paste0(make_summary_gene(data_gene_summary = gene_location, input = data(), var = "cds_length"), " bp"))
       output$gene_summary_entrez_summary <- renderText({
         shiny::validate(
-          need(!is.na(summary_gene(summary_table = gene_summary, input = data(), var = "entrez_summary")), "No data found for this gene."))
-        summary_gene(summary_table = gene_summary, input = data(), var = "entrez_summary") %>% 
+          need(!is.na(make_summary_gene(input = data(), var = "entrez_summary")), "No data found for this gene."))
+        make_summary_gene(input = data(), var = "entrez_summary") %>% 
           lit_linkr(summary_table = gene_summary)})
       output$ncbi_link <- renderText(paste0('<a href="https://www.ncbi.nlm.nih.gov/gene/?term=', 
-                                            summary_gene(summary_table = gene_summary, input = data(), var = "ncbi_gene_id"),
+                                            make_summary_gene(input = data(), var = "ncbi_gene_id"),
                                             '" target="_blank">', 
-                                            summary_gene(summary_table = gene_summary, input = data(), var = "ncbi_gene_id"),
+                                            make_summary_gene(input = data(), var = "ncbi_gene_id"),
                                             '</a>'))
     }
   )
@@ -168,9 +168,9 @@ pathwayTextServer <- function(id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$pathway_title <- renderText({paste0("Pathway: ", summary_pathway(summary_table = pathways, input = data(), var = "pathway"), " (GO:", summary_pathway(summary_table = pathways, input = data(), var = "go"), ")")})
-      output$pathway_gene_symbols <- renderText({summary_pathway(summary_table = pathways, input = data(), var = "data") %>% internal_link()})
-      output$pathway_def <- renderText({summary_pathway(summary_table = pathways, input = data(), var = "def")})
+      output$pathway_title <- renderText({paste0("Pathway: ", make_summary_pathway(input = data(), var = "pathway"), " (GO:", make_summary_pathway(input = data(), var = "go"), ")")})
+      output$pathway_gene_symbols <- renderText({make_summary_pathway(input = data(), var = "data") %>% internal_link()})
+      output$pathway_def <- renderText({make_summary_pathway(input = data(), var = "def")})
     }
   )
 }
@@ -194,18 +194,18 @@ proteinTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$protein_summary_title <- renderText({paste0(summary_protein(summary_table = proteins, input = data(), var = "gene_name"), ": ", summary_protein(summary_table = proteins, input = data(), var = "protein_name"))})
+      output$protein_summary_title <- renderText({paste0(make_summary_protein(input = data(), var = "gene_name"), ": ", make_summary_protein(input = data(), var = "protein_name"))})
       output$ec_link <- renderText(
-        if (is.na(summary_protein(summary_table = proteins, input = data(), var = "ec"))) {paste0('<a href="https://enzyme.expasy.org" target="_blank">', summary_protein(summary_table = proteins, input = data(), var = "ec"),'</a>')
-        } else {paste0('<a href="https://enzyme.expasy.org/EC/', summary_protein(summary_table = proteins, input = data(), var = "ec"), '">', summary_protein(summary_table = proteins, input = data(), var = "ec"),'</a>')
+        if (is.na(make_summary_protein(input = data(), var = "ec"))) {paste0('<a href="https://enzyme.expasy.org" target="_blank">', make_summary_protein(input = data(), var = "ec"),'</a>')
+        } else {paste0('<a href="https://enzyme.expasy.org/EC/', make_summary_protein(input = data(), var = "ec"), '">', make_summary_protein(input = data(), var = "ec"),'</a>')
         })
       output$protein_summary_uniprot_summary <- renderText({
         shiny::validate(
-          need(!is.na(summary_protein(summary_table = proteins, input = data(), var = "function_cc")), "No data found for this protein"))
-        summary_protein(summary_table = proteins, input = data(), var = "function_cc") %>% 
+          need(!is.na(make_summary_protein(input = data(), var = "function_cc")), "No data found for this protein"))
+        make_summary_protein(input = data(), var = "function_cc") %>% 
           lit_linkr(summary_table = gene_summary)})
-      output$uniprot_link <- renderText(paste0('<a href="https://www.uniprot.org/uniprot/', summary_protein(summary_table = proteins, input = data(), var = "uniprot_id"), '" target="_blank">', summary_protein(summary_table = proteins, input = data(), var = "uniprot_id"),'</a>'))
-      output$protein_summary_mass <- renderText(paste0(summary_protein(summary_table = proteins, input = data(), var = "mass"), " kDa"))
+      output$uniprot_link <- renderText(paste0('<a href="https://www.uniprot.org/uniprot/', make_summary_protein(input = data(), var = "uniprot_id"), '" target="_blank">', make_summary_protein(input = data(), var = "uniprot_id"),'</a>'))
+      output$protein_summary_mass <- renderText(paste0(make_summary_protein(input = data(), var = "mass"), " kDa"))
     }
   )
 }
@@ -224,8 +224,8 @@ proteinSeqServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$protein_summary_seq <- renderText(summary_protein(summary_table = proteins, input = data(), var = "sequence"))
-      output$protein_length <- renderText(glue::glue('{stringr::str_length(summary_protein(summary_table = proteins, input = data(), var = "sequence"))} AA'))
+      output$protein_summary_seq <- renderText(make_summary_protein(input = data(), var = "sequence"))
+      output$protein_length <- renderText(glue::glue('{stringr::str_length(make_summary_protein(input = data(), var = "sequence"))} AA'))
           }
   )
 }
@@ -243,7 +243,7 @@ cellTitleServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$cell_summary_title <- renderText({paste0(summary_cell(input = data(), var = "cell_line"), ": ", summary_cell(input = data(), var = "lineage_subtype"))})
+      output$cell_summary_title <- renderText({paste0(make_summary_cell(input = data(), var = "cell_line"), ": ", make_summary_cell(input = data(), var = "lineage_subtype"))})
     }
   )
 }
@@ -258,7 +258,7 @@ lineageTitleServer <- function(id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$lineage_title <- renderText({paste0("Lineage: ", summary_cell(input = data(), var = "lineage"))})
+      output$lineage_title <- renderText({paste0("Lineage: ", make_summary_cell(input = data(), var = "lineage"))})
     }
   )
 }
@@ -273,7 +273,7 @@ lineageSubtypeTitleServer <- function(id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$lineage_subtype_title <- renderText({paste0("Lineage: ", summary_cell(input = data(), var = "lineage_subtype"))})
+      output$lineage_subtype_title <- renderText({paste0("Lineage: ", make_summary_cell(input = data(), var = "lineage_subtype"))})
     }
   )
 }
@@ -319,22 +319,22 @@ cellSummaryTextServer <- function(id, data) {
         data()$query
       })
       output$cell_summary_lineage <- renderText({
-        summary_cell(input = data(), var = "lineage") %>% 
+        make_summary_cell(input = data(), var = "lineage") %>% 
           map_chr(cell_linkr, type = "lineage")
       })
       output$cell_summary_lineage_subtype <- renderText({
-        summary_cell(input = data(), var = "lineage_subtype") %>% 
+        make_summary_cell(input = data(), var = "lineage_subtype") %>% 
           map_chr(cell_linkr, type = "lineage_subtype")
       })
       output$cell_description <- renderText({
-        summary_cellosaurus(input = data(), var = "CC") %>% 
+        make_summary_cellosaurus(input = data(), var = "CC") %>% 
           lit_linkr(summary_table = gene_summary)
       })
       output$cell_age <- renderText({
-        summary_cellosaurus(input = data(), var = "AG")
+        make_summary_cellosaurus(input = data(), var = "AG")
       })
       output$cell_sex <- renderText({
-        summary_cellosaurus(input = data(), var = "SX")
+        make_summary_cellosaurus(input = data(), var = "SX")
       })
     })
 }
@@ -421,9 +421,9 @@ compoundTitleServer <- function (id, data) {
     id,
     function(input, output, session) {
       output$compound_title <- renderText({
-        paste0(summary_compound(summary_table = prism_meta, input = data(), var = "name") %>% stringr::str_to_title(), 
+        paste0(make_summary_compound(input = data(), var = "name") %>% stringr::str_to_title(), 
                ": ", 
-               summary_compound(summary_table = prism_meta, input = data(), var = "moa") %>% stringr::str_to_title())
+               make_summary_compound(input = data(), var = "moa") %>% stringr::str_to_title())
       })
     }
   )
@@ -441,9 +441,9 @@ metaboliteTitleServer <- function (id, data) {
     id,
     function(input, output, session) {
       output$metabolite_title <- renderText({
-        paste0(summary_metabolite(summary_table = hmdb_names, input = data(), var = "name") %>% stringr::str_to_title(),
+        paste0(make_summary_metabolite(input = data(), var = "name") %>% stringr::str_to_title(),
                ": ",
-               summary_metabolite(summary_table = hmdb_names, input = data(), var = "class") %>% stringr::str_to_title())
+               make_summary_metabolite(input = data(), var = "class") %>% stringr::str_to_title())
       })
     }
   )
@@ -462,7 +462,7 @@ moaTitleServer <- function(id, data) {
     function(input, output, session) {
       output$moa_title <- renderText({
         paste0("MOA: ", 
-               summary_compound(summary_table = prism_meta, input = data(), var = "moa") %>% stringr::str_to_title())
+               make_summary_compound(input = data(), var = "moa") %>% stringr::str_to_title())
       })
     }
   )
@@ -479,7 +479,7 @@ compoundListTitleServer <- function(id, data) {
     id,
     function(input, output, session) {
       output$custom_compound_list <- renderText({paste0("Custom Compound List: ", 
-                                                        summary_compound_list(summary_table = prism_meta, input = data())  %>% stringr::str_to_title())
+                                                        make_summary_compound_list(input = data())  %>% stringr::str_to_title())
       })
     }
   )
@@ -512,39 +512,38 @@ compoundSummaryTextServer <- function(id, data) {
           stringr::str_to_title()
       })
       output$compound_summary_description <- renderText({
-        summary_compound(prism_meta, input = data(), var = "description") %>% 
+        make_summary_compound(input = data(), var = "description") %>% 
           stringr::str_to_sentence()
       })
       output$compound_summary_moa <- renderText({
-        summary_compound(prism_meta, input = data(), var = "moa") %>% 
+        make_summary_compound(input = data(), var = "moa") %>% 
           map_chr(moa_linkr)
       })
       output$compound_summary_phase <- renderText({
-        summary_compound(prism_meta, input = data(), var = "phase") %>% 
+        make_summary_compound(input = data(), var = "phase") %>% 
           stringr::str_to_title()
       })
       output$compound_summary_diseasearea <- renderText({
-        summary_compound(prism_meta, input = data(), var = "disease_area") %>% 
+        make_summary_compound(input = data(), var = "disease_area") %>% 
           stringr::str_to_title()
       })
       output$compound_summary_indication <- renderText({
-        summary_compound(prism_meta, input = data(), var = "indication") %>% 
+        make_summary_compound(input = data(), var = "indication") %>% 
           stringr::str_to_title()
       })
       output$compound_summary_targets <- renderText({
-        summary_compound(prism_meta, input = data(), var = "target") %>% 
+        make_summary_compound(input = data(), var = "target") %>% 
           stringr::str_to_upper() %>% 
           map_chr(internal_link)
       })
       output$compound_summary_cid <- renderText({
-        summary_compound(prism_meta, input = data(), var = "cid")
+        make_summary_compound(input = data(), var = "cid")
       })
       output$cid_link <- renderText(paste0('<a href="https://pubchem.ncbi.nlm.nih.gov/compound/', 
-                                           summary_compound(summary_table = prism_meta, input = data(), var = "cid"),
+                                           make_summary_compound(input = data(), var = "cid"),
                                            '" target="_blank">', 
-                                           summary_compound(summary_table = prism_meta, input = data(), var = "cid"),
-                                           '</a>')
-      )
+                                           make_summary_compound(input = data(), var = "cid"),
+                                           '</a>'))
     })
 }
 
@@ -604,7 +603,7 @@ geneGoTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$go_table_title <- renderText({glue::glue('GO pathways for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$go_table_title <- renderText({glue::glue('GO pathways for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -622,7 +621,7 @@ proteinSizeTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$protein_size_title <- renderText({glue::glue('Size Information for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$protein_size_title <- renderText({glue::glue('Size Information for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -641,7 +640,7 @@ proteinSeqTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$protein_seq_title <- renderText({glue::glue('Sequence Information for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$protein_seq_title <- renderText({glue::glue('Sequence Information for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -657,7 +656,7 @@ proteinSignatureTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$protein_signature_title <- renderText({glue::glue('Signature Information for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$protein_signature_title <- renderText({glue::glue('Signature Information for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -673,7 +672,7 @@ proteinStructureTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$protein_structure_title <- renderText({glue::glue('Structural Information for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$protein_structure_title <- renderText({glue::glue('Structural Information for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -691,7 +690,7 @@ cellGeneExpressionTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$cell_gene_table_text <- renderText({glue::glue('Gene expression table for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$cell_gene_table_text <- renderText({glue::glue('Gene expression table for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -707,7 +706,7 @@ cellProteinExpressionPlotTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$cell_protein_text <- renderText({glue::glue('Protein expression plot for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$cell_protein_text <- renderText({glue::glue('Protein expression plot for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -723,7 +722,7 @@ tissuePlotTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$tissueplot_text <- renderText({glue::glue('Human tissue expression plot for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$tissueplot_text <- renderText({glue::glue('Human tissue expression plot for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -739,7 +738,7 @@ tissueTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$tissuetable_text <- renderText({glue::glue('Human tissue expression table for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$tissuetable_text <- renderText({glue::glue('Human tissue expression table for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -756,7 +755,7 @@ cellDepsLinPlotTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$dep_lin_title <- renderText({glue::glue('Dependency lineage plot for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$dep_lin_title <- renderText({glue::glue('Dependency lineage plot for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -772,7 +771,7 @@ cellDepsSubLinPlotTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$dep_sublin_title <- renderText({glue::glue('Dependency sublineage plot for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$dep_sublin_title <- renderText({glue::glue('Dependency sublineage plot for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -790,7 +789,7 @@ cellDependenciesTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$dep_table_title <- renderText({glue::glue('Dependency table for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$dep_table_title <- renderText({glue::glue('Dependency table for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -807,7 +806,7 @@ similarGenesTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$sim_text_title <- renderText({glue::glue('Similar gene table for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$sim_text_title <- renderText({glue::glue('Similar gene table for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -823,7 +822,7 @@ similarPathwaysTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$sim_pathways_text_title <- renderText({glue::glue('Similar pathway table for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$sim_pathways_text_title <- renderText({glue::glue('Similar pathway table for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -839,7 +838,7 @@ dissimilarGenesTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$dsim_text_title <- renderText({glue::glue('Inverse gene table for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$dsim_text_title <- renderText({glue::glue('Inverse gene table for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }
@@ -855,7 +854,7 @@ dissimilarPathwaysTableTextServer <- function (id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$dsim_pathways_text_title <- renderText({glue::glue('Inverse pathway table for {summary_protein(summary_table = proteins, input = data(), var = "gene_name")}')})
+      output$dsim_pathways_text_title <- renderText({glue::glue('Inverse pathway table for {make_summary_protein(input = data(), var = "gene_name")}')})
     }
   )
 }


### PR DESCRIPTION
Renamed all data inputs to functions in the doh package as data_{name of object}, and set all of these as having a default. 

`make_ideogram <- function(data_gene_location = gene_location, data_chromosome = chromosome, input = list(),  card = FALSE)`

In this way, the behavior is consistent with the new ddh_data generator repo, and is explicit about which object the function is expecting.

In practicality, for the app, this means I removed almost all ddh function calls that had an explicit data source, becuase these are now default in the functions in the ddh app.

`make_ideogram (input = list(),  card = FALSE)`

