### PR TITLE
Update pathway search

### DIFF
--- a/code/data.R
+++ b/code/data.R
@@ -3,8 +3,8 @@
 
 ##app----
 gene_surprise <- ddh:::get_content("gene_surprise", dataset = TRUE)
-universal_pathways <- ddh:::get_content("universal_pathways", dataset = TRUE) #makes search pathway table
 universal_gene_summary <- ddh:::get_content("universal_gene_summary", dataset = TRUE)
+universal_pathways <- ddh:::get_content("universal_pathways", dataset = TRUE)
 
 ##search----
 search_index <- ddh:::get_content("search_index", dataset = TRUE)

--- a/code/fun_search.R
+++ b/code/fun_search.R
@@ -35,7 +35,7 @@ multi_query_search <- function(search_index, multi_items) {
     nest()
 }
 
-search_query <- function(search_index, query_str) {
+search_query <- function(search_index, query_str, limit=100) {
   if (is_multi_query_search(query_str)) {
     multi_items <- split_query_str(query_str)
     rows <- multi_query_search(search_index, multi_items)
@@ -45,7 +45,7 @@ search_query <- function(search_index, query_str) {
       multi_items=multi_items
     )
   } else {
-    rows <- single_query_search(search_index, query_str) %>% arrange(desc(rank))
+    rows <- single_query_search(search_index, query_str) %>% arrange(desc(rank)) %>% head(limit)
     list(
       rows=rows,
       multi_query=FALSE,

--- a/code/page_gene.R
+++ b/code/page_gene.R
@@ -498,16 +498,15 @@ genePageServer <- function(id, subtype) {
       } else if (subtype == "pathway"){
         data <- reactive({
           pathway_id <- getQueryString()$query
-          #CHANGE THIS WITH NEW SEARCH INDEX FILE???
-          #universal_pathways <- get_content(object_name = "universal_pathways", dataset = TRUE)
-          pathway_row <- 
-            get_content(object_name = "universal_pathways", dataset = TRUE) %>% #universal_pathways
-            filter(gs_id %in% pathway_id)
+          pathway_genes <- ddh::get_data_object(pathway_id, dataset_name = "universal_pathways") %>%
+            filter(key=="gene_symbol") %>%
+            pull("value")
           list(
             type=type,
             subtype=subtype,
-            query=pathway_go,
-            content=pathway_row$data[[1]]$gene_symbol
+            subtype_id=pathway_id,
+            query=pathway_id,
+            content=pathway_genes
             )
         })
         title_var <- pathwayTitleServer("title_var", data)

--- a/code/page_gene.R
+++ b/code/page_gene.R
@@ -498,9 +498,7 @@ genePageServer <- function(id, subtype) {
       } else if (subtype == "pathway"){
         data <- reactive({
           pathway_id <- getQueryString()$query
-          pathway_genes <- ddh::get_data_object(pathway_id, dataset_name = "universal_pathways") %>%
-            filter(key=="gene_symbol") %>%
-            pull("value")
+          pathway_genes <- ddh::get_gene_symbols_for_pathway(pathway_id)
           list(
             type=type,
             subtype=subtype,

--- a/code/shiny_search.R
+++ b/code/shiny_search.R
@@ -14,18 +14,24 @@ gene_query_result_row <- function(row) {
 }
 
 pathway_query_result_row <- function(row) {
-  pathways_row <- gene_pathways %>%
-    filter(go==row["content_id"])
-  gene_symbols <- lapply(pathways_row$data, function(x) { paste(x$gene, collapse=', ') })
-  title <- paste0(pathways_row$pathway, " (GO:", pathways_row$go, ")")
+  pathway_id <- row["content_id"]
+  pathway_rows <- universal_pathways %>%
+    filter(gs_id==pathway_id)
+  pathway_genes <- paste0(pathway_rows$gene_symbol, collapse=", ")
+  gs_name <- str_replace_all(pathway_rows$gs_name[[1]], "_", " ")
+  gs_description <- pathway_rows$gs_description[[1]]
+
+  title <- paste0(gs_name, " (GSID:", pathway_id, ")")
   list(
     h4(
       tags$strong("Pathway:"),
-      tags$a(title, href=paste0("?show=pathway&query=", pathways_row$go))
+      tags$a(title, href=paste0("?show=pathway&query=", pathway_id))
     ),
     tags$dl(
+      tags$dt("Description"),
+      tags$dd(gs_description),
       tags$dt("Genes"),
-      tags$dd(gene_symbols),
+      tags$dd(pathway_genes),
     ),
     hr()
   )

--- a/code/shiny_text.R
+++ b/code/shiny_text.R
@@ -113,7 +113,7 @@ pathwayTitleServer <- function(id, data) {
   moduleServer(
     id,
     function(input, output, session) {
-      output$pathway_title <- renderText({paste0("Pathway: ", make_summary_pathway(input = data(), var = "pathway"), " (GO:", make_summary_pathway(input = data(), var = "go"), ")")})
+      output$pathway_title <- renderText({paste0("Pathway: ", make_summary_pathway(input = data(), var = "gs_name"), " (Source:", make_summary_pathway(input = data(), var = "gs_exact_source"), ")")})
     }
   )
 }


### PR DESCRIPTION
Changes pathway search to use gs_id instead of go_id. 
Uses get_gene_symbols_for_pathway to lookup gene names for a pathway.
Adds a limit of 100 to search results.

Requires https://github.com/matthewhirschey/ddh/pull/10 