### PR TITLE
Use 1 CPU and 8 GB of memory

### DIFF
--- a/copilot/ddh-app/manifest.yml
+++ b/copilot/ddh-app/manifest.yml
@@ -28,8 +28,8 @@ image:
   # Port exposed through your container to route traffic to it.
   port: 3838
 
-cpu: 4096       # Number of CPU units for the task.
-memory: 20480   # Amount of memory in MiB used by the task.
+cpu: 1024       # Number of CPU units for the task.
+memory: 8192   # Amount of memory in MiB used by the task.
 count: 1       # Number of tasks that should be running in your service.
 exec: true     # Enable running commands in your container.
 


### PR DESCRIPTION
Now that we are using less memory in the app I reduced the memory to 8 GB. This allowed me to lower the number of CPUs requested as well. Since the open source shiny server only uses 1 CPU. Previously we allocated 4 CPU to get to the higher memory threshold previously required by the app.