### PR TITLE
update outseta js for user login management

### DIFF
--- a/code/app/outseta.js
+++ b/code/app/outseta.js
@@ -2,19 +2,60 @@
 <script>
   var o_options = {
     domain: 'ddh.outseta.com'
+    // keep users logged in across multiple tabs
+    tokenStorage: 'local',
   };
 </script>
+<!-- Outseta Script (doing all the magic) -->
 <script src="https://cdn.outseta.com/outseta.min.js"
         data-options="o_options">
 </script>
 
+<!-- Custom Code Snippet to redirect the user back to a protected content page they were attempting to access after login -->
+<script>
+  // 1. Store the URL of the page the user attempted to access
+  Outseta.on('nocode.accessDenied', () => {
+    if (!Outseta.getAccessToken()) {
+      // This is an unauthenticated user (not a wrong plan user),
+      // so store the current url.
+      sessionStorage.setItem('postLoginUrl', window.location.href);
+    }
+  });
+
+  // 2. Redirect the user to the stored URL after they log in
+  Outseta.on('redirect', (redirectUrl) => {
+    const redirectURL = new URL(redirectUrl);
+    const accessToken = redirectURL.searchParams.get("access_token");
+
+    if (accessToken) {
+      // This is a login redirect, so let's
+      // see if we have a stored postLoginUrl URL
+      const postLoginUrl = sessionStorage.getItem('postLoginUrl');
+      
+      if (postLoginUrl) {
+        // Remove the stored postLoginUrl URL
+        sessionStorage.removeItem('postLoginUrl');
+        
+        // Redirect to the stored URL,
+        // with the accessToken appended
+        const newRedirectUrl = new URL(postLoginUrl);
+        newRedirectUrl.searchParams.set("access_token", accessToken);
+        window.location.href = newRedirectUrl.href;
+
+        // Disable redirect to original redirectUrl
+        return false;
+      }
+    }
+  }); 
+</script>
+
 <!-- Chat Embed -->
 <script>
-  var o_options = {
+  var o_options_chat = {
     domain: 'ddh.outseta.com',
     load: 'chat'
   };
 </script>
 <script src="https://cdn.outseta.com/outseta.min.js"
-        data-options="o_options">
+        data-options="o_options_chat">
 </script>


### PR DESCRIPTION
Added ability to keep users logged in across multiple tabs, and allows a redirect to attempted page after auth. 

This should allow unauthenticated users to: 
1. click a link to access a query page (like from an email)
2. get redirected to login
3. return to the attempted query page

This should also allow authenticated users to:
1. Click on a link from the .com app
2. open a new tab that is authenticated and fetched that query.
3. ultimately allowing users to have multiple windows/tabs open for .com

*also implements chat var rename