### PR TITLE
Fix downloading methods.zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY code/index_org /srv/code/index_org
 COPY code/index_com /srv/code/index_com
 
 COPY code/app /srv/code/app/
+RUN chown shiny:shiny /srv/code/app/www
 COPY ./shiny-server-org.conf /etc/shiny-server/shiny-server-org.conf
 COPY ./shiny-server-com.conf /etc/shiny-server/shiny-server-com.conf
 

--- a/code/app/methods.R
+++ b/code/app/methods.R
@@ -15,4 +15,4 @@ download_methods <- function(){
   on.exit(unlink(methods_key))
   message("Downloaded and unzipped methods")
 }
-download_methods()
+try(download_methods())


### PR DESCRIPTION
Changes permissions so the shiny app can download and unzip methods. Also changes the methods logic to not crash the app if there is a problem downloading methods.