### PR TITLE
Fix metabolite search results

### DIFF
--- a/code/app/shiny_search.R
+++ b/code/app/shiny_search.R
@@ -187,7 +187,8 @@ moa_query_result_row <- function(row) {
 
 metabolite_query_result_row <- function(row) {
   hmdb_name_row <- compound_hmdb_names %>%
-    filter(cid==row["content_id"])
+    filter(cid==row["content_id"]) %>%
+    head(1)
   list(
     h4(
       tags$strong("Metabolite:"),


### PR DESCRIPTION
Some metabolites have multiple names that match the same cid. This caused a problem when rendering the search results. The change here uses the first metabolite found that matches the cid.